### PR TITLE
More portable dummy filter

### DIFF
--- a/src/main/java/com/gentics/graphqlfilter/filter/operation/Comparison.java
+++ b/src/main/java/com/gentics/graphqlfilter/filter/operation/Comparison.java
@@ -167,7 +167,7 @@ public class Comparison extends AbstractOperation<FilterOperand<?>> implements C
 	 * @return
 	 */
 	public static final Comparison dummy(boolean shouldSucceed, String initiatingFilterName) {
-		return new Comparison(shouldSucceed ? "=" : "<>", new LiteralOperand<>(1, false), new LiteralOperand<>(1, false), initiatingFilterName);
+		return new Comparison(shouldSucceed ? "IS" : "IS NOT", new LiteralOperand<>("NULL", false), new LiteralOperand<>("NULL", false), initiatingFilterName);
 	}
 
 	@Override


### PR DESCRIPTION
Replace `1 = 1`/`1 <> 1` dummy filters with `NULL IS NULL`/`NULL IS NOT NULL`, that are more dialect friendly.